### PR TITLE
removed wildcard from query param

### DIFF
--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -160,7 +160,7 @@ class ElasticsearchEngine extends Engine
             'body' => [
                 'query' => [
                     'bool' => [
-                        'must' => [['query_string' => [ 'query' => "*{$builder->query}*"]]]
+                        'must' => [['query_string' => [ 'query' => "{$builder->query}"]]]
                     ]
                 ]
             ]


### PR DESCRIPTION
There seemed to have been some conflicts with the wildcards within the query param when using an n-gram configuration. Search would only return the model that was preforming the search opposed to the fuzzy ngram results we'd expect.

My suspicion is that it has something to do with the need to avoid using '[fuzziness with wildcards](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#avoid-widlcards-fuzzy-searches)' though fuzziness uses Levenshtein distance, not n-grams.
